### PR TITLE
Receive the endpoint and token as params

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ And then execute:
 bundle install
 ```
 
-## Configure the environment variables
-```
-# .env
-PDF_MERGER_API_ENDPOINT=https://your.custom.endpoint/api/v1/pdf/merge
-PDF_MERGER_TOKEN=the-token
-```
-
 ## Usage
 
 ```ruby
@@ -34,6 +27,22 @@ file_urls = [
 ]
 output_path = './output.pdf'
 
-merger = PdfMerger::Merger.new(file_urls, output_path, skip_token: true)
+merger = PdfMerger::Merger.new(file_urls, output_path, skip_token: true, api_endpoint: 'https://your.custom.endpoint/api/v1/pdf/merge')
+merger.merge
+```
+
+or with a token
+
+```ruby
+
+require 'pdf_merger'
+
+file_urls = [
+  'https://s3-public.de/file1.pdf',
+  'https://s3-public.de/file2.pdf'
+]
+output_path = './output.pdf'
+
+merger = PdfMerger::Merger.new(file_urls, output_path, skip_token: false, api_endpoint: 'https://your.custom.endpoint/api/v1/pdf/merge', api_token: 'the-token')
 merger.merge
 ```

--- a/lib/pdf_merger.rb
+++ b/lib/pdf_merger.rb
@@ -9,19 +9,18 @@ module PdfMerger
   class Error < StandardError; end
 
   class Merger
-    API_ENDPOINT = ENV.fetch('PDF_MERGER_API_ENDPOINT', nil)
-    API_TOKEN = ENV.fetch('PDF_MERGER_TOKEN', nil)
-
-    def initialize(file_urls, output_path, skip_token: false)
+    def initialize(file_urls, output_path, skip_token: false, api_endpoint:, api_token: nil)
       @file_urls = file_urls
       @output_path = output_path
       @skip_token = skip_token
+      @api_endpoint = api_endpoint
+      @api_token = api_token
     end
 
     def merge
-      uri = URI(API_ENDPOINT)
+      uri = URI(api_endpoint)
       request = Net::HTTP::Post.new(uri)
-      request['token'] = API_TOKEN unless skip_token
+      request['token'] = api_token unless skip_token
       form_data = file_urls.map { |url| ["files", url] }
       
       request.set_form form_data, 'multipart/form-data'
@@ -40,6 +39,7 @@ module PdfMerger
 
     private
 
-    attr_reader :file_urls, :output_path, :skip_token
+    attr_reader :file_urls, :output_path,
+                :skip_token, :api_endpoint, :api_token
   end
 end


### PR DESCRIPTION
Removing the option to save these values as env vars, but actually set them as params of the initializator of the class